### PR TITLE
Fix maintain state of fragment while selecting images

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -7,9 +7,10 @@
 
     <application android:largeHeap="true">
         <activity android:name="com.github.windsekirun.naraeimagepicker.activity.NaraePickerActivity"
+            android:configChanges="keyboardHidden|orientation"
             android:theme="@style/Theme.AppCompat.Light.DarkActionBar"/>
         <activity android:name="com.github.windsekirun.naraeimagepicker.activity.ImageDetailsActivity"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar"/>
+            android:theme="@style/NoActionBar"/>
     </application>
 
 </manifest>

--- a/library/src/main/java/com/github/windsekirun/naraeimagepicker/activity/ImageDetailsActivity.kt
+++ b/library/src/main/java/com/github/windsekirun/naraeimagepicker/activity/ImageDetailsActivity.kt
@@ -1,13 +1,10 @@
 package com.github.windsekirun.naraeimagepicker.activity
 
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
+import android.view.View
 import com.github.windsekirun.naraeimagepicker.Constants
-import com.github.windsekirun.naraeimagepicker.module.PickerSet
-import com.github.windsekirun.naraeimagepicker.utils.applyCustomPickerTheme
 import com.github.windsekirun.naraeimagepicker.utils.loadImage
 import kotlinx.android.synthetic.main.activity_image_details.*
 import pyxis.uzuki.live.naraeimagepicker.R
@@ -24,23 +21,23 @@ import pyxis.uzuki.live.naraeimagepicker.R
 class ImageDetailsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        applyCustomPickerTheme(PickerSet.getSettingItem())
+//        applyCustomPickerTheme(PickerSet.getSettingItem())
         setContentView(R.layout.activity_image_details)
 
         val path = intent.getStringExtra(Constants.EXTRA_DETAIL_IMAGE)
 
+        setSupportActionBar(toolbar)
         supportActionBar?.apply {
-            setBackgroundDrawable(ColorDrawable(ContextCompat.getColor(this@ImageDetailsActivity, android.R.color.black)))
             title = ""
             setDisplayHomeAsUpEnabled(true)
-            hide()
         }
+        card_toolbar.visibility = View.GONE
 
         photoView.setOnViewTapListener { _, _, _ ->
-            if (supportActionBar?.isShowing == true) {
-                supportActionBar?.hide()
+            if (card_toolbar.visibility == View.VISIBLE) {
+                card_toolbar.visibility = View.GONE
             } else {
-                supportActionBar?.show()
+                card_toolbar.visibility = View.VISIBLE
             }
         }
 

--- a/library/src/main/java/com/github/windsekirun/naraeimagepicker/activity/ImageDetailsActivity.kt
+++ b/library/src/main/java/com/github/windsekirun/naraeimagepicker/activity/ImageDetailsActivity.kt
@@ -21,7 +21,6 @@ import pyxis.uzuki.live.naraeimagepicker.R
 class ImageDetailsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-//        applyCustomPickerTheme(PickerSet.getSettingItem())
         setContentView(R.layout.activity_image_details)
 
         val path = intent.getStringExtra(Constants.EXTRA_DETAIL_IMAGE)
@@ -31,14 +30,10 @@ class ImageDetailsActivity : AppCompatActivity() {
             title = ""
             setDisplayHomeAsUpEnabled(true)
         }
-        card_toolbar.visibility = View.GONE
+        cardToolbar.visibility = View.GONE
 
         photoView.setOnViewTapListener { _, _, _ ->
-            if (card_toolbar.visibility == View.VISIBLE) {
-                card_toolbar.visibility = View.GONE
-            } else {
-                card_toolbar.visibility = View.VISIBLE
-            }
+            cardToolbar.visibility = if (cardToolbar.visibility == View.VISIBLE) View.GONE else View.VISIBLE
         }
 
         photoView.loadImage(path)

--- a/library/src/main/res/layout/activity_image_details.xml
+++ b/library/src/main/res/layout/activity_image_details.xml
@@ -1,12 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000"
-    android:orientation="vertical">
+    android:background="@android:color/black">
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="@android:color/transparent"
+        app:cardCornerRadius="0dp"
+        app:cardElevation="1dp">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:background="@android:color/transparent"
+            android:minHeight="?actionBarSize" />
+    </android.support.v7.widget.CardView>
 
     <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/photoView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</LinearLayout>
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true" />
+
+</RelativeLayout>

--- a/library/src/main/res/layout/activity_image_details.xml
+++ b/library/src/main/res/layout/activity_image_details.xml
@@ -6,7 +6,7 @@
     android:background="@android:color/black">
 
     <android.support.v7.widget.CardView
-        android:id="@+id/card_toolbar"
+        android:id="@+id/cardToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:cardBackgroundColor="@android:color/transparent"

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="NoActionBar" parent="Theme.AppCompat.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
 - Fix maintain the state of fragment onconfig changes
 - Fix flicker while show/hide in ImageDetailsActivity

To fix the flicker I used toolbar wrapped in card view (To handle the click listener for back button) with elevation. I don't know it's the best way or not but in this way we can provide the back compatibility without using the android:elevation attribute.